### PR TITLE
gsynth: change how score is computed and refactor code a bit

### DIFF
--- a/src/common.sh
+++ b/src/common.sh
@@ -28,6 +28,7 @@ binaryCompileOptions["lloops"]="lloops.c cpuidc.c -lm ${extraLinkerOptions}"
 binaryCompileOptions["whetstonemp"]="mp/whetsmp.c mp/cpuidc64.c -pthread -lm ${extraLinkerOptions}"
 binaryCompileOptions["mpmflops"]="mp/mpmflops.c mp/cpuidc64.c -pthread -lm ${extraLinkerOptions}"
 binaryCompileOptions["busspeedil"]="busspeed.c cpuidc.c -lm ${extraLinkerOptions}"
+binaryCompileOptions["gsynth"]="gsynth/gsynth.cpp -lm -lstdc++"
 
 coremarkCompileOptions="-Icoremark/${coremarkPlatform} -Icoremark -DPERFORMANCE_RUN=1 -DUSE_FORK=1  ${extraLinkerOptions} coremark/core_list_join.c coremark/core_main.c coremark/core_matrix.c coremark/core_state.c coremark/core_util.c coremark/${coremarkPlatform}/core_portme.c"
 
@@ -54,8 +55,8 @@ if [[ ${current_uname} == "Darwin" ]]; then
 	os_name="mac"
 fi
 
-echo -e "Arch: ${current_arch}\n"
-echo -e "Uname: ${current_uname}\n"
+echo "Arch: ${current_arch}"
+echo "Uname: ${current_uname}"
 echo -e "Cpu cores: ${cpus_count}\n"
 
 optFlags="-O2 -O3 -Ofast"
@@ -64,6 +65,13 @@ optFlags="-O2 -O3 -Ofast"
 # compile_binary function will iterate over all variants of flags specified by targetToFlags
 declare -A targetToFlags
 declare -A targetToFPU
+
+if [[ ${#} -eq 1 ]]; then
+	if [[ ${1} == "list" ]] || [[ ${1} == "ls" ]]; then
+		echo "Available benchmarks: ${!binaryCompileOptions[@]}"
+		exit 0;
+	fi
+fi
 
 compile_binary() {
     ARCH=${1}
@@ -91,7 +99,7 @@ compile_binary() {
                 if [[ ${BINARY_NAME} =~ ^coremark ]]; then
                     BINARY_EXTRA_FLAGS[0]="-DFLAGS_STR=\"${OPT} ${EXTRA_CFLAGS} -DPERFORMANCE_RUN=1 -DUSE_FORK=1 -lrt\""
                 fi
-                ${CC} ${binaryCompileOptions[${BINARY}]} "${BINARY_EXTRA_FLAGS[@]}" -o ${output_dir}/${BINARY_NAME} ${OPT} ${EXTRA_CFLAGS} -D options="\"${current_arch} ${ARCH} optimized\""
+                "${CC}" ${binaryCompileOptions[${BINARY}]} "${BINARY_EXTRA_FLAGS[@]}" -o "${output_dir}/${BINARY_NAME}" ${OPT} ${EXTRA_CFLAGS} -D options="\"${current_arch} ${ARCH} optimized\""
                 chmod +x ${output_dir}/${BINARY_NAME}
             done
         done

--- a/src/common.sh
+++ b/src/common.sh
@@ -28,7 +28,7 @@ binaryCompileOptions["lloops"]="lloops.c cpuidc.c -lm ${extraLinkerOptions}"
 binaryCompileOptions["whetstonemp"]="mp/whetsmp.c mp/cpuidc64.c -pthread -lm ${extraLinkerOptions}"
 binaryCompileOptions["mpmflops"]="mp/mpmflops.c mp/cpuidc64.c -pthread -lm ${extraLinkerOptions}"
 binaryCompileOptions["busspeedil"]="busspeed.c cpuidc.c -lm ${extraLinkerOptions}"
-binaryCompileOptions["gsynth"]="gsynth/gsynth.cpp -lm -lstdc++"
+binaryCompileOptions["gsynth"]="gsynth/gsynth.cpp -std=c++11 -lm -lstdc++"
 
 coremarkCompileOptions="-Icoremark/${coremarkPlatform} -Icoremark -DPERFORMANCE_RUN=1 -DUSE_FORK=1  ${extraLinkerOptions} coremark/core_list_join.c coremark/core_main.c coremark/core_matrix.c coremark/core_state.c coremark/core_util.c coremark/${coremarkPlatform}/core_portme.c"
 
@@ -99,8 +99,12 @@ compile_binary() {
                 if [[ ${BINARY_NAME} =~ ^coremark ]]; then
                     BINARY_EXTRA_FLAGS[0]="-DFLAGS_STR=\"${OPT} ${EXTRA_CFLAGS} -DPERFORMANCE_RUN=1 -DUSE_FORK=1 -lrt\""
                 fi
-                "${CC}" ${binaryCompileOptions[${BINARY}]} "${BINARY_EXTRA_FLAGS[@]}" -o "${output_dir}/${BINARY_NAME}" ${OPT} ${EXTRA_CFLAGS} -D options="\"${current_arch} ${ARCH} optimized\""
-                chmod +x ${output_dir}/${BINARY_NAME}
+		if [[ ${BINARY_NAME} =~ ^gsynth ]]; then
+                	"${CC}" ${binaryCompileOptions[${BINARY}]} "${BINARY_EXTRA_FLAGS[@]}" -o "${output_dir}/${BINARY_NAME}" ${OPT} ${EXTRA_CFLAGS}
+		else
+                	"${CC}" ${binaryCompileOptions[${BINARY}]} "${BINARY_EXTRA_FLAGS[@]}" -o "${output_dir}/${BINARY_NAME}" ${OPT} ${EXTRA_CFLAGS} -D options="\"${current_arch} ${ARCH} optimized\""
+		fi
+		chmod +x ${output_dir}/${BINARY_NAME}
             done
         done
     done

--- a/src/gsynth/gsynth.cpp
+++ b/src/gsynth/gsynth.cpp
@@ -12,7 +12,7 @@
 
 using namespace std;
 
-#define BENCMARK_RENDER_TIME 400.0f
+#define BENCHMARK_RENDER_TIME 400.0f
 #define PLAY_FREQ 48000
 #define INV_PLAY_FREQ (1.0f / PLAY_FREQ)
 #define MAX_SAMPLES 8
@@ -290,8 +290,11 @@ void render_to_file(const char *file_name, float seconds)
 
 
     stop = clock();
-    printf("time=%g\n", double(stop - start) / CLOCKS_PER_SEC);
-    printf("score=%d\n", int(20000.0f / (double(stop - start) / CLOCKS_PER_SEC)));
+    double time = double(stop - start) / CLOCKS_PER_SEC;
+    double score = seconds / time;
+    printf("g_synth_length_seconds=%g\n", seconds);
+    printf("g_synth_time=%g\n", time);
+    printf("g_synth_score=%g\n", score);
 
     for (int n = 0; n < N; n++)
     {
@@ -347,16 +350,23 @@ void render_to_memory(float seconds)
     _tmp += samples[1234];
 
     stop = clock();
-    printf("g_synth_time=%g\n", double(stop - start) / CLOCKS_PER_SEC);
-    printf("g_synth_score=%d\n", int(20000.0f / (double(stop - start) / CLOCKS_PER_SEC)));
+    double time = double(stop - start) / CLOCKS_PER_SEC;
+    double score = seconds / time;
+    printf("g_synth_length_seconds=%g\n", seconds);
+    printf("g_synth_time=%g\n", time);
+    printf("g_synth_score=%g\n", score);
 
     delete[] samples;
   }
 }
 
-int main()
+int main(int argc, char * argv[])
 {
-  render_to_memory(BENCMARK_RENDER_TIME);
-//  render_to_file("result.wav", BENCMARK_RENDER_TIME);
+  float seconds = BENCHMARK_RENDER_TIME;
+  if (argc == 2) {
+    seconds = std::stof(argv[1]);
+  }
+  render_to_memory(seconds);
+//  render_to_file("result.wav", BENCHMARK_RENDER_TIME);
   return 0;
 }

--- a/src/gsynth/gsynth.cpp
+++ b/src/gsynth/gsynth.cpp
@@ -1,3 +1,4 @@
+#include <chrono>
 #include <cmath>
 #include <cstring>
 #include <ctime>
@@ -250,9 +251,7 @@ void fill_samples(float * samples, int N, float seconds)
   synth[1].setParams(global_freq[1], 0, 0.5, 0.1f, 0.0f, 4.2f, 0.1f);
   synth[2].setParams(global_freq[2], 3, 0.15, 0.05f, 0.0f, 10.0f, 0.9f);
 
-
-  clock_t start, stop;
-  start = clock();
+  auto start = std::chrono::high_resolution_clock::now();
 
   int step = 256;
   float baseFreq = 0.5;
@@ -262,11 +261,13 @@ void fill_samples(float * samples, int N, float seconds)
       synth[t].fillBuffer(samples + i, step);
 
 
-  stop = clock();
-  double time = double(stop - start) / CLOCKS_PER_SEC;
-  double score = seconds / time;
+  auto stop = std::chrono::high_resolution_clock::now();
+
+  std::chrono::duration<double> time = stop - start;
+  double score = seconds / time.count();
+
   std::cout<<"g_synth_length_seconds="<<seconds<<std::endl;
-  std::cout<<"g_synth_time="<<time<<std::endl;
+  std::cout<<"g_synth_time="<<time.count()<<std::endl;
   std::cout<<"g_synth_score="<<score<<std::endl;
 }
 

--- a/src/make-amd64.sh
+++ b/src/make-amd64.sh
@@ -1,9 +1,18 @@
+#!/usr/bin/env bash
 # Include common functions and operations
 source common.sh
 
 targetToFlags["x86-64"]="-march=znver2"
 targetToFPU["x86-64"]=""
 
+if [[ ${#} -eq 1 ]]; then
+	echo "Compiling only ${1}"
+	BINARY="${1}"
+    	for ARCH in "${!targetToFlags[@]}"; do
+        	compile_binary ${ARCH} ${BINARY} amd64
+    	done
+	exit 0
+fi
 
 for BINARY in "${!binaryCompileOptions[@]}"; do
     for ARCH in "${!targetToFlags[@]}"; do

--- a/src/make-amd64_clang.sh
+++ b/src/make-amd64_clang.sh
@@ -1,8 +1,18 @@
+#!/usr/bin/env bash
 # Include common functions and operations
 source common.sh
 
 targetToFlags["x86-64"]="-march=znver2"
 targetToFPU["x86-64"]=""
+
+if [[ ${#} -eq 1 ]]; then
+	echo "Compiling only ${1}"
+	BINARY="${1}"
+    	for ARCH in "${!targetToFlags[@]}"; do
+        	compile_binary ${ARCH} ${BINARY} amd64 clang
+    	done
+	exit 0
+fi
 
 for BINARY in "${!binaryCompileOptions[@]}"; do
     for ARCH in "${!targetToFlags[@]}"; do

--- a/src/make-arm.sh
+++ b/src/make-arm.sh
@@ -32,6 +32,14 @@ else
     targetToFPU["armv8.1-a"]=""
 fi
 
+if [[ ${#} -eq 1 ]]; then
+	echo "Compiling only ${1}"
+	BINARY="${1}"
+    	for ARCH in "${!targetToFlags[@]}"; do
+        	compile_binary ${ARCH} ${BINARY} arm
+    	done
+	exit 0
+fi
 
 for BINARY in "${!binaryCompileOptions[@]}"; do
     for ARCH in "${!targetToFlags[@]}"; do

--- a/src/make-e2k.sh
+++ b/src/make-e2k.sh
@@ -18,6 +18,15 @@ targetToFPU["elbrus-v4"]="-ffast -fwhole"
 targetToFPU["elbrus-v5"]="-ffast -fwhole"
 targetToFPU["elbrus-v6"]="-ffast -fwhole"
 
+if [[ ${#} -eq 1 ]]; then
+	echo "Compiling only ${1}"
+	BINARY="${1}"
+    	for ARCH in "${!targetToFlags[@]}"; do
+        	compile_binary ${ARCH} ${BINARY} e2k
+    	done
+	exit 0
+fi
+
 for BINARY in "${!binaryCompileOptions[@]}"; do
     for ARCH in "${!targetToFlags[@]}"; do
         compile_binary ${ARCH} ${BINARY} e2k

--- a/src/make-i386.sh
+++ b/src/make-i386.sh
@@ -1,9 +1,18 @@
+#!/usr/bin/env bash
 # Include common functions and operations
 source common.sh
 
 targetToFlags["i386"]="-march=i386"
 targetToFPU["i386"]=""
 
+if [[ ${#} -eq 1 ]]; then
+	echo "Compiling only ${1}"
+	BINARY="${1}"
+    	for ARCH in "${!targetToFlags[@]}"; do
+        	compile_binary ${ARCH} ${BINARY} i386
+    	done
+	exit 0
+fi
 
 for BINARY in "${!binaryCompileOptions[@]}"; do
     for ARCH in "${!targetToFlags[@]}"; do

--- a/src/make-loongarch64.sh
+++ b/src/make-loongarch64.sh
@@ -7,6 +7,14 @@ binaryCompileOptions["mpmflops"]="-I./include/ mp/mpmflops_s.c mp/cpuidc64.c -pt
 targetToFlags["loongarch64"]="-march=native"
 targetToFPU["loongarch64"]=""
 
+if [[ ${#} -eq 1 ]]; then
+	echo "Compiling only ${1}"
+	BINARY="${1}"
+    	for ARCH in "${!targetToFlags[@]}"; do
+        	compile_binary ${ARCH} ${BINARY} loongarch64
+    	done
+	exit 0
+fi
 
 for BINARY in "${!binaryCompileOptions[@]}"; do
     for ARCH in "${!targetToFlags[@]}"; do

--- a/src/make-mac-arm.sh
+++ b/src/make-mac-arm.sh
@@ -9,7 +9,16 @@ set -e
 # aarch64
 targetToFlags["native"]=""
 targetToFlags["armv8.4-a"]="-mcpu=apple-m1"
-    
+
+if [[ ${#} -eq 1 ]]; then
+	echo "Compiling only ${1}"
+	BINARY="${1}"
+    	for ARCH in "${!targetToFlags[@]}"; do
+        	compile_binary ${ARCH} ${BINARY} arm
+    	done
+	exit 0
+fi
+
 for BINARY in "${!binaryCompileOptions[@]}"; do
     for ARCH in "${!targetToFlags[@]}"; do
         compile_binary ${ARCH} ${BINARY} arm

--- a/src/make-sparc64.sh
+++ b/src/make-sparc64.sh
@@ -1,8 +1,18 @@
+#!/usr/bin/env bash
 # Include common functions and operations
 source common.sh
 
 targetToFlags["sparc64"]="-mcpu=v9"
 dotToFPU["sparc64"]=""
+
+if [[ ${#} -eq 1 ]]; then
+	echo "Compiling only ${1}"
+	BINARY="${1}"
+    	for ARCH in "${!targetToFlags[@]}"; do
+        	compile_binary ${ARCH} ${BINARY} sparc64
+    	done
+	exit 0
+fi
 
 for BINARY in "${!binaryCompileOptions[@]}"; do
 	for ARCH in "${!targetToFlags[@]}"; do

--- a/src/run-gsynth.sh
+++ b/src/run-gsynth.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source common-gsynth.sh
 
 RESULT_DIR="../results/${current_arch}"


### PR DESCRIPTION
 * Improve build script to allow it to build only specific binary (makes `make-amd64-gsynth.sh` obsolete as it can be replaced with `make-amd64.sh gsynth`)
 * Change score to be independent of generation length time (it now computes speed-up relative to real-time)
 * Refactor code a bit (make it more idiomatic C++ and move out common part to a separate function) 